### PR TITLE
Fix settings.cpp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,5 @@ include/*
 lib/*
 bin/*
 test/test_runner
+
+.cache

--- a/src/settings/settings.cpp
+++ b/src/settings/settings.cpp
@@ -1,6 +1,7 @@
 #include <list>
 #include <iostream>
 #include <filesystem>
+#include <fstream>
 #include <toml++/toml.h>
 #ifdef LOCAL_PLATFORM_FOLDERS
 #include <platform_folders.h>


### PR DESCRIPTION
settings.cpp was missing an include causing builds to fail